### PR TITLE
Add .editorconfig; add license to progress_bar.sh

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+# https://editorconfig.org
+
+root=true
+
+[*]
+end_of_line = LF
+indent_style = space
+indent_size = 4

--- a/progress_bar.sh
+++ b/progress_bar.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# https://github.com/pollev/bash_progress_bar - See license at end of file
 
 # Usage:
 # Source this script
@@ -9,7 +10,6 @@
 # block_progress_bar 45 <- turns the progress bar yellow to indicate some action is requested from the user
 # draw_progress_bar 90 <- advance progress bar
 # destroy_scroll_area <- remove progress bar
-
 
 # Constants
 CODE_SAVE_CURSOR="\033[s"
@@ -171,3 +171,26 @@ printf_new() {
     v=$(printf "%-${num}s" "$str")
     echo -ne "${v// /$str}"
 }
+
+
+# SPDX-License-Identifier: MIT
+#
+# Copyright (c) 2018--2020 Polle Vanhoof
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.


### PR DESCRIPTION
Thank you for this project, which looks very useful!  I am planning to add support for a custom trap function, which is a feature I need.  In the mean time, this small PR is to add two documentation changes:

- Add an [.editorconfig file](https://editorconfig.org) to set up the project's 4-space indentation in supported editors (I am an EditorConfig team member and use it heavily :) )
- Add the license text and an [SPDX license identifier](https://spdx.dev/ids/) to `progress_bar.sh`.  I will be copying that file into my own project at `$work` and don't want the license information to be separated from the file.  Credit where credit is due!

Thank you for considering this PR!